### PR TITLE
Update ch16.md

### DIFF
--- a/docs/ch16.md
+++ b/docs/ch16.md
@@ -220,7 +220,7 @@ In this decoupling mode the components all execute in the same address space, an
 
 - Deployment level. We can control the dependencies between deployable units such as jar files, DLLs, or shared libraries, so that changes to the source code in one module do not force others to be rebuilt and redeployed.
 
-> - 部署层次：我们可以控制部署单元（譬如 jar 文件、DLL、共享库等）之间 的依赖关系，以此来实现一个模块的变更不会导致其他模块的重新构建和部署。
+> - 部署层次：我们可以控制部署单元（譬如 jar 文件、DLL、共享库等）之间的依赖关系，以此来实现一个模块的变更不会导致其他模块的重新构建和部署。
 
 Many of the components may still live in the same address space, and communicate through function calls. Other components may live in other processes in the same processor, and communicate through interprocess communications, sockets, or shared memory. The important thing here is that the decoupled components are partitioned into independently deployable units such as jar files, Gem files, or DLLs.
 


### PR DESCRIPTION
（没有改）第7行少了半句话 ： “正如我们之前所述，” 的原文为 “As we previously stated, a good architecture must support:” 
第223行：删除一个多余的空格